### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+[![Board Status](https://dev.azure.com/22594919870801/8c2fcd21-02e4-4ef9-a45d-4f588b2527d9/4ae17f27-4c06-4697-b56d-3f5f7eaea086/_apis/work/boardbadge/b4eb3b2b-2d49-4093-8dc9-37e93c8f34a9)](https://dev.azure.com/22594919870801/8c2fcd21-02e4-4ef9-a45d-4f588b2527d9/_boards/board/t/4ae17f27-4c06-4697-b56d-3f5f7eaea086/Microsoft.RequirementCategory)


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes [AB#2](https://dev.azure.com/22594919870801/8c2fcd21-02e4-4ef9-a45d-4f588b2527d9/_workitems/edit/2). See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.